### PR TITLE
Fix potential false positive hydra results

### DIFF
--- a/delta/collectors/hydra/__init__.py
+++ b/delta/collectors/hydra/__init__.py
@@ -205,5 +205,5 @@ class Hydra(Collector):
             elif line.startswith("[ERROR]"):
                 data["error"] = line
         data["results"] = results
-        data["vulnerable"] = len(results) > 0
+        data["vulnerable"] = None if (data["error"]) else len(results) > 0
         return data


### PR DESCRIPTION
In the previous implementation we would set `data["vulnerable"] = false` if hydra exited with an error. Now it returns None in the error case.

This might still not be totally correct. For example ssh errors out when the server does not support password login. In this case the server is not vulnerable.

It does not appear that error messages are standardized across different ssh servers, so it is not trivial to handle this case.

For now we will err on the side of caution.